### PR TITLE
Enhance metadata extraction in `unfurl` function

### DIFF
--- a/src/lib/server/helpers/unfurl.test.ts
+++ b/src/lib/server/helpers/unfurl.test.ts
@@ -3,11 +3,16 @@ import { unfurl } from './unfurl'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const ARTICLE_HTML = `
-<html>
+<html lang="en">
 <head>
     <title>Test Article</title>
     <meta property="og:title" content="OG Article Title">
     <meta property="og:type" content="article">
+    <meta property="description" content="A test article for unfurling.">
+    <meta property="author" content="Jane Doe">
+    <meta property="og:site_name" content="Test Site">
+    <meta property="article:published_time" content="2025-06-26T12:00:00Z">
+    <meta property="og:image" content="https://example.com/image.jpg">
 </head>
 <body>
     <article><h1>Heading</h1><p>Some content here.</p></article>
@@ -16,10 +21,15 @@ const ARTICLE_HTML = `
 `
 
 const VIDEO_HTML = `
-<html>
+<html lang="fr">
 <head>
     <meta property="og:title" content="OG Video Title">
     <meta property="og:type" content="video">
+    <meta property="og:description" content="A test video for unfurling.">
+    <meta property="article:author" content="John Smith">
+    <meta property="og:site_name" content="Video Site">
+    <meta property="og:published_time" content="2025-06-25T10:00:00Z">
+    <meta property="twitter:image" content="https://example.com/video.jpg">
 </head>
 <body>Video Content</body>
 </html>
@@ -54,8 +64,17 @@ describe('unfurl', () => {
         expect(result.title).toBe('OG Article Title')
         expect(result.type).toBe('article')
         if (result.content) {
-            expect(result.content).toContain('Some content here')
+            expect(result.content).toContain('<h1>Heading</h1><p>Some content here.</p>')
         }
+        expect(result.textContent).toContain('Some content here')
+        expect(result.length).toBeGreaterThan(0)
+        expect(result.excerpt).toBe('A test article for unfurling.')
+        expect(result.byline).toBe('Jane Doe')
+        expect(result.dir).toBeUndefined()
+        expect(result.siteName).toBe('Test Site')
+        expect(result.lang).toBe('en')
+        expect(result.publishedTime).toBe('2025-06-26T12:00:00Z')
+        expect(result.image).toBe('https://example.com/image.jpg')
     })
 
     it('extracts metadata for a video type', async () => {
@@ -68,6 +87,15 @@ describe('unfurl', () => {
         expect(result.title).toBe('OG Video Title')
         expect(result.type).toBe('video')
         expect(result.content).toBeUndefined()
+        expect(result.textContent).toContain('Video Content')
+        expect(result.length).toBeGreaterThan(0)
+        expect(result.excerpt).toBe('A test video for unfurling.')
+        expect(result.byline).toBe('John Smith')
+        expect(result.dir).toBeUndefined()
+        expect(result.siteName).toBe('Video Site')
+        expect(result.lang).toBe('fr')
+        expect(result.publishedTime).toBe('2025-06-25T10:00:00Z')
+        expect(result.image).toBe('https://example.com/video.jpg')
     })
 
     it('falls back to document title if no og:title', async () => {

--- a/src/lib/server/helpers/unfurl.ts
+++ b/src/lib/server/helpers/unfurl.ts
@@ -32,6 +32,12 @@ type URLMetadata = {
     image?: string,
 }
 
+/**
+ * Unfurls the URL and extracts all the relevant metadata
+ * @param url The URL of the resource to parse
+ * @returns The parsed and extracted metadata from the URL resource
+ * @throws If the fetch response is not ok
+ */
 export async function unfurl(url: string): Promise<URLMetadata> {
     // Fetch the URL resource
     const response = await fetch(url)
@@ -53,11 +59,45 @@ export async function unfurl(url: string): Promise<URLMetadata> {
     }
 
     // Extract metadata like title and social image from open-graph tags / html
-    const title = readability?.title || dom.getMeta('og:title') || dom.document.title || url
-    const image = dom.getMeta('og:image') ?? dom.getMeta('twitter:image')
-    const content = readability?.content || dom.document?.textContent || undefined
+    const title =
+        readability?.title ||
+        dom.getMeta('og:title') ||
+        dom.document.title ||
+        url
 
-    // TODO: Readability returns quite a bit of information like lang, textContent, length, excerpt, siteName, publishedTime. Use them. See See https://github.com/mozilla/readability?tab=readme-ov-file#parse
+    const content = readability?.content ?? undefined
+    const textContent = readability?.textContent ?? dom.document.body?.textContent ?? undefined
+    const length = readability?.length ?? textContent?.length ?? 0
+    const excerpt =
+        readability?.excerpt ||
+        dom.getMeta('description') ||
+        dom.getMeta('og:description') ||
+        undefined
+    const byline =
+        readability?.byline ||
+        dom.getMeta('author') ||
+        dom.getMeta('article:author') ||
+        undefined
+    const dir = readability?.dir ?? undefined
+    const siteName =
+        readability?.siteName ||
+        dom.getMeta('og:site_name') ||
+        dom.document.location.hostname
+    const lang =
+        readability?.lang ||
+        dom.document.documentElement.lang ||
+        undefined
+    const publishedTime =
+        readability?.publishedTime ||
+        dom.getMeta('article:published_time') ||
+        dom.getMeta('og:published_time') ||
+        undefined
+    const image =
+        dom.getMeta('og:image') ||
+        dom.getMeta('twitter:image') ||
+        undefined
+
+
     // TODO: Sanitize the content and use CSP. See https://github.com/mozilla/readability?tab=readme-ov-file#security
 
     // Determine the content type
@@ -72,8 +112,17 @@ export async function unfurl(url: string): Promise<URLMetadata> {
 
     return {
         title,
+        type,
         content,
-        type
+        textContent,
+        length,
+        excerpt,
+        byline,
+        dir,
+        siteName,
+        lang,
+        publishedTime,
+        image,
     }
 }
 

--- a/src/lib/server/helpers/unfurl.ts
+++ b/src/lib/server/helpers/unfurl.ts
@@ -6,9 +6,30 @@ import { isProbablyReaderable, Readability } from '@mozilla/readability'
 import type { ItemType } from '../../server/database/schema/saves'
 
 type URLMetadata = {
+    /** Title of the article */
     title: string,
-    content?: string,
+    /** The type of the article */
     type: ItemType,
+    /** HTML string of the processed article content */
+    content?: string,
+    /** Text Content of the article, with all the HTML tags removed */
+    textContent?: string,
+    /** Length of an article, in characters */
+    length?: number,
+    /** Article description, or short excerpt from the content */
+    excerpt?: string,
+    /** Author metadata */
+    byline?: string,
+    /** Content direction */
+    dir?: string,
+    /** Name of the site */
+    siteName?: string,
+    /** Content language */
+    lang?: string,
+    /** Published time */
+    publishedTime?: string,
+    /** Thumbnail image */
+    image?: string,
 }
 
 export async function unfurl(url: string): Promise<URLMetadata> {

--- a/src/lib/server/helpers/unfurl.ts
+++ b/src/lib/server/helpers/unfurl.ts
@@ -65,6 +65,8 @@ export async function unfurl(url: string): Promise<URLMetadata> {
         dom.document.title ||
         url
 
+    // TODO: Sanitize the content and use CSP. See https://github.com/mozilla/readability?tab=readme-ov-file#security
+
     const content = readability?.content ?? undefined
     const textContent = readability?.textContent ?? dom.document.body?.textContent ?? undefined
     const length = readability?.length ?? textContent?.length ?? 0
@@ -97,9 +99,6 @@ export async function unfurl(url: string): Promise<URLMetadata> {
         dom.getMeta('twitter:image') ||
         undefined
 
-
-    // TODO: Sanitize the content and use CSP. See https://github.com/mozilla/readability?tab=readme-ov-file#security
-
     // Determine the content type
     //? Again, maybe content-type or mime-type would be a better indicator?
     const ogType = dom.getMeta('og:type') ?? dom.getMeta('medium') ?? ''
@@ -126,6 +125,11 @@ export async function unfurl(url: string): Promise<URLMetadata> {
     }
 }
 
+// -------
+// HELPERS
+// -------
+
+/** Extends the JSDOM class with some helpers */
 class DOM extends JSDOM {
     constructor(html: string, url: string) {
         super(html, { url })
@@ -135,8 +139,9 @@ class DOM extends JSDOM {
         return this.window.document
     }
 
-    getMeta(prop: string) {
-        return this.window.document.querySelector(`meta[property="${prop}"]`)?.getAttribute('content') ??
-            this.window.document.querySelector(`meta[name="${prop}"]`)?.getAttribute('content')
+    /** @return The content value of the given property's meta tag */
+    getMeta(property: string) {
+        return this.window.document.querySelector(`meta[property="${property}"]`)?.getAttribute('content') ??
+            this.window.document.querySelector(`meta[name="${property}"]`)?.getAttribute('content')
     }
 }


### PR DESCRIPTION
Improve the `URLMetadata` type by adding new properties and enhance the `unfurl` function to extract additional metadata fields. Update tests to cover the new metadata extraction for articles and videos.